### PR TITLE
Generate decorate item event for all menu items on active item change.

### DIFF
--- a/Sources/MenuBarView/MenuBarView.swift
+++ b/Sources/MenuBarView/MenuBarView.swift
@@ -56,9 +56,13 @@ public class MenuBarView: UIView {
                 newValue < stackView.arrangedSubviews.count &&
                 newValue != prActiveMenuIndex {
                 prActiveMenuIndex = newValue
+                delegate?.onActiveMenuChange(index: prActiveMenuIndex)
                 let button = stackView.arrangedSubviews[prActiveMenuIndex] as! UIButton
                 animateSelectionChange(selectedMenu: button)
-                delegate?.onActiveMenuChange(index: prActiveMenuIndex)
+                for (index, arrangedSubview) in stackView.arrangedSubviews.enumerated() {
+                    delegate?.decorateMenu(button: arrangedSubview as! UIButton,
+                                           forIndex: index)
+                }
             }
         }
     }


### PR DESCRIPTION
The delegate method `decorateMenu` is now called on all menu items whenever the active menu item is changed.

This provides an opportunity to update styling on all items.