### PR TITLE
Bug Fix: In some cases the title label of one of the buttons could appear truncated (in middle)

### DIFF
--- a/Sources/MenuBarView/MenuBarView.swift
+++ b/Sources/MenuBarView/MenuBarView.swift
@@ -157,6 +157,7 @@ public class MenuBarView: UIView {
             delegate?.decorateMenu(button: button, forIndex: index)
             stackView.addArrangedSubview(button)
             button.addTarget(self, action: #selector(self.pressed(sender:)), for: .touchUpInside)
+            button.titleLabel?.lineBreakMode = .byClipping
         }
         
         setNeedsLayout()


### PR DESCRIPTION
In some scenarios, the title label of the button gets truncated even though it does not need to.
It appears that setting the line-break mode to `byClipping` is more robust than the default mode (`byTruncatingMiddle`).