### PR TITLE
Bug fix: In some cases the title label of one of the buttons could appear truncated

### DIFF
--- a/Sources/MenuBarView/MenuBarView.swift
+++ b/Sources/MenuBarView/MenuBarView.swift
@@ -154,6 +154,7 @@ public class MenuBarView: UIView {
         for index in 0..<labels.count {
             let button = UIButton()
             button.setTitle(labels[index], for: .normal)
+            button.titleLabel?.lineBreakMode = .byClipping
             delegate?.decorateMenu(button: button, forIndex: index)
             stackView.addArrangedSubview(button)
             button.addTarget(self, action: #selector(self.pressed(sender:)), for: .touchUpInside)


### PR DESCRIPTION
In some scenarios, the title label of the button gets truncated even though it does not need to.
It appears that setting the line-break mode to `byClipping` is more robust than the default mode (`byTruncatingMiddle`).